### PR TITLE
Use PostgreSQL hstore data type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,4 @@ before_script:
   - psql -c 'create database dashboard_travis' -U postgres
 script:
   - RAILS_ENV=test bundle exec rake db:migrate
-  - bundle exec rake db:test:prepare
   - bundle exec rspec spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: ruby
+cache: bundler
 rvm:
   - 1.9.3
   - 2.0.0
-script: bundle exec rspec
+before_script:
+  - cp spec/dummy/config/database.travis.yml spec/dummy/config/database.yml
+  - psql -c 'create database dashboard_travis' -U postgres
+script:
+  - RAILS_ENV=test bundle exec rake db:migrate
+  - bundle exec rake db:test:prepare
+  - bundle exec rspec spec

--- a/detour.gemspec
+++ b/detour.gemspec
@@ -19,12 +19,13 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 1.9.3"
 
   spec.add_dependency "rails", "~> 3.2.16"
+  spec.add_dependency "pg", "~> 0.17.0"
+  spec.add_dependency "activerecord-postgres-hstore", "~> 0.7.7"
 
   spec.add_development_dependency "capybara"
   spec.add_development_dependency "factory_girl_rails"
   spec.add_development_dependency "pry-debugger"
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "shoulda-matchers"
-  spec.add_development_dependency "sqlite3-ruby"
   spec.add_development_dependency "yard"
 end

--- a/lib/generators/templates/migration.rb
+++ b/lib/generators/templates/migration.rb
@@ -1,5 +1,7 @@
 class SetupDetour < ActiveRecord::Migration
   def change
+    execute "CREATE EXTENSION IF NOT EXISTS hstore"
+
     create_table :detour_features do |t|
       t.string :name
       t.integer :failure_count, default: 0

--- a/spec/dummy/config/database.travis.yml
+++ b/spec/dummy/config/database.travis.yml
@@ -1,0 +1,6 @@
+test: &postgresql
+  adapter: postgresql
+  username: postgres
+  password:
+  database: dashboard_travis
+  min_messages: ERROR

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -1,19 +1,11 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
 development:
-  adapter: sqlite3
-  database: db/development.sqlite3
+  adapter: postgresql
+  database: detour-development
   pool: 5
   timeout: 5000
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
-  adapter: sqlite3
-  database: db/test.sqlite3
+  adapter: postgresql
+  database: detour-test
   pool: 5
   timeout: 5000

--- a/spec/dummy/db/migrate/20131218081531_setup_detour.rb
+++ b/spec/dummy/db/migrate/20131218081531_setup_detour.rb
@@ -1,5 +1,7 @@
 class SetupDetour < ActiveRecord::Migration
   def change
+    execute "CREATE EXTENSION IF NOT EXISTS hstore"
+
     create_table :detour_features do |t|
       t.string :name
       t.integer :failure_count, default: 0

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20131218023124) do
+ActiveRecord::Schema.define(:version => 20131218081531) do
 
   create_table "detour_features", :force => true do |t|
     t.string   "name"


### PR DESCRIPTION
Using the hstore data type for percentage and group rollouts would significantly improve the speed of and reduce the complexity of Detour, especially in the complex summary views of the admin interface.

Percentage rollouts would be deserialized like:

``` ruby
percentage_rollouts: { "users" => "20", "widgets" => "100" }
```

Group rollouts would need to use a key prefix, and would be deserialized like:

``` ruby
group_rollouts: { "users|admins" => "1", "users|foo" => "1", "widgets|foo" => "1" }
```

It's worth keeping in mind that this introduces a PostgreSQL dependency for Detour and projects using it.

This might necessitate finding a way to run `CREATE EXTENSION IF NOT EXISTS hstore` outside of a migration in order to prevent forcing project to use a SQL schema instead of the standard Ruby schema.
